### PR TITLE
feat: Implement method `ignoreItems` for Recipe Mod Restrictions

### DIFF
--- a/src/main/java/com/alessandro/astages/core/client/manager/AClientRecipeManager.java
+++ b/src/main/java/com/alessandro/astages/core/client/manager/AClientRecipeManager.java
@@ -58,9 +58,9 @@ public class AClientRecipeManager implements AClientMinimalManager<AClientBaseRe
     }
 
     public AClientBaseRecipeRestriction<?, ?, ?> getRestriction(AClientHolder holder, RecipeWrapper wrapper) {
-        var serverModRestriction = mods.stream().filter(r -> r.getModId().equals(wrapper.recipe().getNamespace()) && !AStagesClientUtils.hasStage(holder, AStageType.SERVER, r.getStage())).findFirst().orElse(null);
+        var serverModRestriction = mods.stream().filter(r -> r.isRestricted(wrapper) && !AStagesClientUtils.hasStage(holder, AStageType.SERVER, r.getStage())).findFirst().orElse(null);
         if (serverModRestriction == null) { return null; }
-        var modRestriction = mods.stream().filter(r -> r.getModId().equals(wrapper.recipe().getNamespace()) && !AStagesClientUtils.hasStage(holder, AStageType.PLAYER, r.getStage())).findFirst().orElse(null);
+        var modRestriction = mods.stream().filter(r -> r.isRestricted(wrapper) && !AStagesClientUtils.hasStage(holder, AStageType.PLAYER, r.getStage())).findFirst().orElse(null);
         if (modRestriction != null) { return modRestriction; }
 
         var restrictions = RECIPE_TYPE_CACHE.get(wrapper.type());

--- a/src/main/java/com/alessandro/astages/core/client/restriction/recipe/AClientRecipeModRestriction.java
+++ b/src/main/java/com/alessandro/astages/core/client/restriction/recipe/AClientRecipeModRestriction.java
@@ -2,16 +2,19 @@ package com.alessandro.astages.core.client.restriction.recipe;
 
 import com.alessandro.astages.api.nullability.NotNullParams;
 import com.alessandro.astages.core.AClientRestrictionManager;
-import com.alessandro.astages.core.AStageManager;
-import com.alessandro.astages.core.server.restriction.item.ABaseItemRestriction;
 import com.alessandro.astages.core.wrapper.RecipeModWrapper;
 import com.alessandro.astages.core.wrapper.RecipeWrapper;
 import com.alessandro.astages.store.AttributeStore;
+import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @NotNullParams
 public class AClientRecipeModRestriction extends AClientBaseRecipeRestriction<AClientRecipeModRestriction, RecipeModWrapper, RecipeWrapper> {
     private String modId = null;
+    private final List<ResourceLocation> ignoredRecipeIds = new ArrayList<>();
 
     public AClientRecipeModRestriction(String id, String stage) {
         super(id, stage);
@@ -33,10 +36,19 @@ public class AClientRecipeModRestriction extends AClientBaseRecipeRestriction<AC
 
     @Override
     public boolean isRestricted(RecipeWrapper wrapper) {
-        return modId.equals(wrapper.recipe().getNamespace());
+        return modId.equals(wrapper.recipe().getNamespace()) && !ignoredRecipeIds.contains(wrapper.recipe());
+    }
+
+    public AClientRecipeModRestriction ignoreItems(List<ResourceLocation> recipeIds) {
+        ignoredRecipeIds.addAll(recipeIds);
+        return this;
     }
 
     public String getModId() {
         return modId;
+    }
+
+    public List<ResourceLocation> getIgnoredRecipeIds() {
+        return ignoredRecipeIds;
     }
 }

--- a/src/main/java/com/alessandro/astages/core/server/restriction/item/ABaseItemRestriction.java
+++ b/src/main/java/com/alessandro/astages/core/server/restriction/item/ABaseItemRestriction.java
@@ -210,12 +210,6 @@ public class ABaseItemRestriction<R extends ARestriction<R, U, ItemStack>, U> ex
     }
 
     @SuppressWarnings("unused")
-    public ABaseItemRestriction<R, U> setHiddenName(String name) {
-        set(Attributes.Item.HIDDEN_NAME, stack -> Component.literal(name));
-        return this;
-    }
-
-    @SuppressWarnings("unused")
     public ABaseItemRestriction<R, U> setDropMessage(Function<ItemStack, Component> message) {
         set(Attributes.Item.DROP_MESSAGE, message);
         return this;
@@ -230,12 +224,6 @@ public class ABaseItemRestriction<R extends ARestriction<R, U, ItemStack>, U> ex
     @SuppressWarnings("unused")
     public ABaseItemRestriction<R, U> setPickupMessage(Function<ItemStack, Component> message) {
         set(Attributes.Item.PICKING_UP_MESSAGE, message);
-        return this;
-    }
-
-    @SuppressWarnings("unused")
-    public ABaseItemRestriction<R, U> setPickupMessage(String message) {
-        set(Attributes.Item.PICKING_UP_MESSAGE, stack -> Component.literal(message));
         return this;
     }
 

--- a/src/main/java/com/alessandro/astages/core/server/restriction/item/ABaseItemRestriction.java
+++ b/src/main/java/com/alessandro/astages/core/server/restriction/item/ABaseItemRestriction.java
@@ -210,6 +210,12 @@ public class ABaseItemRestriction<R extends ARestriction<R, U, ItemStack>, U> ex
     }
 
     @SuppressWarnings("unused")
+    public ABaseItemRestriction<R, U> setHiddenName(String name) {
+        set(Attributes.Item.HIDDEN_NAME, stack -> Component.literal(name));
+        return this;
+    }
+
+    @SuppressWarnings("unused")
     public ABaseItemRestriction<R, U> setDropMessage(Function<ItemStack, Component> message) {
         set(Attributes.Item.DROP_MESSAGE, message);
         return this;
@@ -224,6 +230,12 @@ public class ABaseItemRestriction<R extends ARestriction<R, U, ItemStack>, U> ex
     @SuppressWarnings("unused")
     public ABaseItemRestriction<R, U> setPickupMessage(Function<ItemStack, Component> message) {
         set(Attributes.Item.PICKING_UP_MESSAGE, message);
+        return this;
+    }
+
+    @SuppressWarnings("unused")
+    public ABaseItemRestriction<R, U> setPickupMessage(String message) {
+        set(Attributes.Item.PICKING_UP_MESSAGE, stack -> Component.literal(message));
         return this;
     }
 

--- a/src/main/java/com/alessandro/astages/core/server/restriction/recipe/ARecipeModRestriction.java
+++ b/src/main/java/com/alessandro/astages/core/server/restriction/recipe/ARecipeModRestriction.java
@@ -7,10 +7,15 @@ import com.alessandro.astages.core.wrapper.RecipeWrapper;
 import com.alessandro.astages.networking.ANetworking;
 import com.alessandro.astages.networking.packet.recipe.RecipeModSyncerS2CPacket;
 import com.alessandro.astages.store.AttributeStore;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @NotNullParamsAndMethodsReturn
 public class ARecipeModRestriction extends ABaseRecipeRestriction<ARecipeModRestriction, RecipeModWrapper, RecipeWrapper> {
     private String modId = null;
+    private final List<ResourceLocation> ignoredRecipeIds = new ArrayList<>();
 
     public ARecipeModRestriction(String id, String stage) {
         super(id, stage);
@@ -37,11 +42,23 @@ public class ARecipeModRestriction extends ABaseRecipeRestriction<ARecipeModRest
 
     @Override
     public boolean isRestricted(RecipeWrapper wrapper) {
-        return modId.equals(wrapper.recipe().getNamespace());
+        return modId.equals(wrapper.recipe().getNamespace()) && !ignoredRecipeIds.contains(wrapper.recipe());
+    }
+
+    @SuppressWarnings("unused")
+    public ARecipeModRestriction ignoreItems(String... itemIds) {
+        for (var id : itemIds) {
+            ignoredRecipeIds.add(ResourceLocation.parse(id));
+        }
+        return this;
     }
 
     public String getModId() {
         return modId;
+    }
+
+    public List<ResourceLocation> getIgnoredRecipeIds() {
+        return ignoredRecipeIds;
     }
 
     @Override

--- a/src/main/java/com/alessandro/astages/integration/jei/ARecipeStagesJEIPlugin.java
+++ b/src/main/java/com/alessandro/astages/integration/jei/ARecipeStagesJEIPlugin.java
@@ -106,19 +106,20 @@ public class ARecipeStagesJEIPlugin implements IModPlugin {
 
     private void restrictAllRecipesForMods() {
         for (var mod : AClientRestrictionManager.RECIPE_INSTANCE.mods) {
-            restrictAllRecipesForModAndType(RecipeTypes.CRAFTING, mod.getModId(), mod.getStage());
-            restrictAllRecipesForModAndType(RecipeTypes.SMELTING, mod.getModId(), mod.getStage());
-            restrictAllRecipesForModAndType(RecipeTypes.SMOKING, mod.getModId(), mod.getStage());
-            restrictAllRecipesForModAndType(RecipeTypes.CAMPFIRE_COOKING, mod.getModId(), mod.getStage());
-            restrictAllRecipesForModAndType(RecipeTypes.BLASTING, mod.getModId(), mod.getStage());
-            restrictAllRecipesForModAndType(RecipeTypes.SMITHING, mod.getModId(), mod.getStage());
-            restrictAllRecipesForModAndType(RecipeTypes.STONECUTTING, mod.getModId(), mod.getStage());
+            var ignored = mod.getIgnoredRecipeIds();
+            restrictAllRecipesForModAndType(RecipeTypes.CRAFTING, mod.getModId(), mod.getStage(), ignored);
+            restrictAllRecipesForModAndType(RecipeTypes.SMELTING, mod.getModId(), mod.getStage(), ignored);
+            restrictAllRecipesForModAndType(RecipeTypes.SMOKING, mod.getModId(), mod.getStage(), ignored);
+            restrictAllRecipesForModAndType(RecipeTypes.CAMPFIRE_COOKING, mod.getModId(), mod.getStage(), ignored);
+            restrictAllRecipesForModAndType(RecipeTypes.BLASTING, mod.getModId(), mod.getStage(), ignored);
+            restrictAllRecipesForModAndType(RecipeTypes.SMITHING, mod.getModId(), mod.getStage(), ignored);
+            restrictAllRecipesForModAndType(RecipeTypes.STONECUTTING, mod.getModId(), mod.getStage(), ignored);
         }
     }
 
-    private <C extends Container, T extends Recipe<C>> void restrictAllRecipesForModAndType(mezz.jei.api.recipe.RecipeType<T> type, String modId, String stage) {
+    private <C extends Container, T extends Recipe<C>> void restrictAllRecipesForModAndType(mezz.jei.api.recipe.RecipeType<T> type, String modId, String stage, List<ResourceLocation> ignoredRecipeIds) {
         var newList = runtime.getRecipeManager().createRecipeLookup(type).includeHidden().get()
-            .filter(r -> r.getId().getNamespace().equals(modId))
+            .filter(r -> r.getId().getNamespace().equals(modId) && !ignoredRecipeIds.contains(r.getId()))
             .toList();
 
         if (AStagesClientUtils.hasStage(AClientHolder.serverAndPlayer(), stage)) {

--- a/src/main/java/com/alessandro/astages/networking/packet/recipe/RecipeModSyncerS2CPacket.java
+++ b/src/main/java/com/alessandro/astages/networking/packet/recipe/RecipeModSyncerS2CPacket.java
@@ -8,39 +8,47 @@ import com.alessandro.astages.networking.packet.RestrictionSyncerPacket;
 import com.alessandro.astages.api.nullability.NotNullParams;
 import com.alessandro.astages.api.develop.Info;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.List;
 
 @NotNullParams
 @Info("For now, required only by JEI.")
 public class RecipeModSyncerS2CPacket extends RestrictionSyncerPacket {
     private final int priority;
     private final String modId;
+    private final List<ResourceLocation> ignoredRecipeIds;
 
     public RecipeModSyncerS2CPacket(ARecipeModRestriction restriction) {
-        this(restriction.getId(), restriction.getStage(), restriction.getPriority(), restriction.getModId());
+        this(restriction.getId(), restriction.getStage(), restriction.getPriority(), restriction.getModId(), restriction.getIgnoredRecipeIds());
     }
 
-    public RecipeModSyncerS2CPacket(String id, String stage, int priority, String modId) {
+    public RecipeModSyncerS2CPacket(String id, String stage, int priority, String modId, List<ResourceLocation> ignoredRecipeIds) {
         super(id, stage);
         this.priority = priority;
         this.modId = modId;
+        this.ignoredRecipeIds = ignoredRecipeIds;
     }
 
     public RecipeModSyncerS2CPacket(FriendlyByteBuf buf) {
         super(buf);
         this.priority = buf.readInt();
         this.modId = buf.readUtf();
+        this.ignoredRecipeIds = buf.readList(FriendlyByteBuf::readResourceLocation);
     }
 
     public void toBytes(FriendlyByteBuf buf) {
         super.toBytes(buf);
         buf.writeInt(priority);
         buf.writeUtf(modId);
+        buf.writeCollection(ignoredRecipeIds, FriendlyByteBuf::writeResourceLocation);
     }
 
     @Override
     public void handle() {
         var restriction = new AClientRecipeModRestriction(getId(), getStage())
-                .restrict(new RecipeModWrapper(modId));
+                .restrict(new RecipeModWrapper(modId))
+                .ignoreItems(ignoredRecipeIds);
 
         AClientRestrictionManager.RECIPE_INSTANCE.addRestriction(restriction);
     }


### PR DESCRIPTION
Closes #71

  - Add setHiddenName(String) and setPickupMessage(String) convenience overloads to ABaseItemRestriction
  - Add ignoreItems(String...) to ARecipeModRestriction with full server/client/packet/JEI support
  - Update AClientRecipeManager to use isRestricted() so ignored recipe IDs are respected client-side
Context

 All methods requested in #71 (setHideInJEI, setHideTooltip, setHiddenName, setCanPickedUp, setPickupMessage, setCanBeDig) already exist on ABaseItemRestriction and are inherited by Tag and Mod restrictions. 
The missing piece was ignoreItems for addRestrictionForModRecipe, which previously blanket-wiped every recipe for a mod with no way to exempt specific ones.

 Sadly could not test the built jar in our modpack (likely due to breaking changes between 1.4 and 2.0-alpha)