### PR TITLE
fix: NullPointerExecption in onPlayerTick when scanning all slots for enchanted books

### DIFF
--- a/src/main/java/com/alessandro/astages/infrastructure/hook/restriction/EnchantServerEvents.java
+++ b/src/main/java/com/alessandro/astages/infrastructure/hook/restriction/EnchantServerEvents.java
@@ -41,7 +41,7 @@ public class EnchantServerEvents {
                         var parsedBook = removeAllRestrictedEnchantmentFromEnchantedBook(player, slotContent);
 
                         if (!parsedBook.isEmpty()) {
-                            inventory.setItem(CommonEventSettings.getSlotChanged(), parsedBook);
+                            inventory.setItem(i, parsedBook);
                         }
                     } else if (slotContent.isEnchanted()) {
                         removeAllRestrictedEnchantmentFromStack(player, slotContent);


### PR DESCRIPTION
In the slot==null branch (full inventory sweep), inventory.setItem was passing CommonEventSettings.getSlotChanged(), which is guaranteed null in this branch, instead of the loop counter i. Auto-unbox to int produced NPE on any inventory containing an enchanted book.

fixes #106 